### PR TITLE
Use UTF-8 to decode downloaded async data

### DIFF
--- a/twitter_ads/http.py
+++ b/twitter_ads/http.py
@@ -133,7 +133,7 @@ class Response(object):
             # Content-Type: application/json
             # instead it returns:
             # Content-Type: application/gzip
-            raw_response_body = zlib.decompress(self._raw_body, 16 + zlib.MAX_WBITS).decode()
+            raw_response_body = zlib.decompress(self._raw_body, 16 + zlib.MAX_WBITS).decode('utf-8')
         else:
             raw_response_body = self._raw_body
 


### PR DESCRIPTION
Sometimes there are special UTF-8 characters in the data that cannot be decoded by the default ASCII